### PR TITLE
Apply AIX xlC13 fix (already in OpenJ9)

### DIFF
--- a/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
+++ b/src/java.base/share/native/libjimage/NativeImageBuffer.cpp
@@ -41,6 +41,16 @@
 #include "jimage.hpp"
 #include "osSupport.hpp"
 
+#if defined(__xlC__) && (__xlC__ >= 0x0d01)
+/*
+ * Version 13.1.3 of xlc seems to have trouble parsing the `__attribute__`
+ * annotation in the generated header file we're about to include. Repeating
+ * the forward declaration (without the braces) here avoids the diagnostic:
+ *   1540-0040 (S) The text "void" is unexpected.  "visibility" may be undeclared or ambiguous.
+ */
+extern "C" JNIEXPORT jobject JNICALL Java_jdk_internal_jimage_NativeImageBuffer_getNativeMap(JNIEnv *, jclass, jstring);
+#endif
+
 #include "jdk_internal_jimage_NativeImageBuffer.h"
 
 

--- a/src/java.base/unix/native/include/jni_md.h
+++ b/src/java.base/unix/native/include/jni_md.h
@@ -37,6 +37,9 @@
     #define JNIEXPORT     __attribute__((visibility("default")))
     #define JNIIMPORT     __attribute__((visibility("default")))
   #endif
+#elif defined(__xlC__) && (__xlC__ >= 0x0d01) /* xlc version 13.1 or better required */
+  #define JNIEXPORT       __attribute__((visibility("default")))
+  #define JNIIMPORT       __attribute__((visibility("default")))
 #else
   #define JNIEXPORT
   #define JNIIMPORT


### PR DESCRIPTION
Hopefully resolves https://github.com/AdoptOpenJDK/openjdk-build/issues/456 (applies the patch from //patch-diff.githubusercontent.com/raw/ibmruntimes/openj9-openjdk-jdk11/pull/15.patch